### PR TITLE
paginate by hour, not by day

### DIFF
--- a/tap_platformpurple/streams/base.py
+++ b/tap_platformpurple/streams/base.py
@@ -49,7 +49,7 @@ class BaseDatePaginatedPlatformPurpleStream(BasePlatformPurpleStream):
         else:
             start_date = start_date.replace(tzinfo=pytz.UTC)
 
-        end_date = start_date + datetime.timedelta(days=1)
+        end_date = start_date + datetime.timedelta(hours=1)
 
         while not done:
             max_date = start_date


### PR DESCRIPTION
Per recommendation from a Platform Purple dev, we should be paginating by hour, not by day. This will help alleviate periodic timeouts returning data from the API.