### PR TITLE
Bug: tap was using wrong page duration

### DIFF
--- a/tap_platformpurple/streams/base.py
+++ b/tap_platformpurple/streams/base.py
@@ -104,6 +104,6 @@ class BaseDatePaginatedPlatformPurpleStream(BasePlatformPurpleStream):
                 LOGGER.info("Advancing by one page.")
                 start_date = max_date
 
-            end_date = start_date + datetime.timedelta(days=7)
+            end_date = start_date + datetime.timedelta(hours=1)
 
             save_state(self.state)


### PR DESCRIPTION
I missed this when I opened #2 .

Tested by running the tap with the problematic config locally. Works fine now, pulls much smaller pages.